### PR TITLE
Signup db autoseeding

### DIFF
--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -1,7 +1,8 @@
 const router = require("express").Router();
-const { user } = require("../../models");
+const { user, ownedGame, achievement, } = require("../../models");
 const sequelize = require("../../config/connection");
 const fetch = require("node-fetch");
+require("dotenv").config();
 
 // CREATE new user
 router.post("/signup", async (req, res) => {
@@ -12,8 +13,54 @@ router.post("/signup", async (req, res) => {
       steam_id: req.body.steamid,
     });
 
-    // take user data and fetch ownedgames and achievements, then store in db
+    /* take user data and fetch ownedgames and achievements, then store in db */
 
+    // fetch owned games by provided steamid
+    const dbGameData = await fetch(
+      "http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=" +
+        process.env.API_KEY +
+        "&steamid=" +
+        req.body.steamid +
+        "&format=json&include_appinfo=true&"
+    )
+      .then((res) => res.json())
+      .then((data) => data);
+
+    // destructure response to access games array
+    const { response } = dbGameData;
+    const { games } = response;
+
+    // remove unused parts of the objects within games array, returning a new array seedData
+    const seedData = games.map((game) => {
+      delete game.playtime_forever;
+      delete game.has_community_visible_stats;
+      delete game.playtime_windows_forever;
+      delete game.playtime_mac_forever;
+      delete game.playtime_linux_forever;
+      delete game.rtime_last_played;
+      return game;
+    });
+
+    console.dir(seedData);
+
+    // get user_id of the user we just created
+    const userId = await user.findOne({
+      where: {
+        email: req.body.email
+      }
+    });
+    const {id} = userId;
+
+    // then seed that game data into db using seedData
+    // link to user by "find user where email=req.body.email" to get newly created user
+    for (const game of seedData) {
+      await ownedGame.create({
+        ...game,
+        user_id: id
+      });
+    }
+
+    // set logged in state to true and save to session cookie
     req.session.save(() => {
       req.session.loggedIn = true;
 
@@ -73,6 +120,5 @@ router.post("/logout", (req, res) => {
     res.status(404).end();
   }
 });
-
 
 module.exports = router;

--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -31,6 +31,7 @@ router.post("/signup", async (req, res) => {
     const { games } = response;
 
     // remove unused parts of the objects within games array, returning a new array seedData
+    // can re-integrate this data later on by removing its delete command here and updating the ownedGame model to include a column for it
     const seedData = games.map((game) => {
       delete game.playtime_forever;
       delete game.has_community_visible_stats;
@@ -40,8 +41,6 @@ router.post("/signup", async (req, res) => {
       delete game.rtime_last_played;
       return game;
     });
-
-    console.dir(seedData);
 
     // get user_id of the user we just created
     const userId = await user.findOne({

--- a/models/achievement.js
+++ b/models/achievement.js
@@ -32,7 +32,7 @@ achievement.init(
       type: DataTypes.INTEGER,
       references: {
         model: "ownedGame",
-        key: "appid",
+        key: "id",
       },
     },
   },

--- a/models/ownedGame.js
+++ b/models/ownedGame.js
@@ -5,10 +5,15 @@ class ownedGame extends Model {}
 
 ownedGame.init(
     {
-      appid: {
+      id: {
         type: DataTypes.INTEGER,
         allowNull: false,
         primaryKey: true,
+        autoIncrement: true,
+      },
+      appid: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
       },
       name: {
         type: DataTypes.STRING,

--- a/seeds/gameData.json
+++ b/seeds/gameData.json
@@ -1,21 +1,21 @@
 [
     {
-        "appid": "1",
+        "appid": "4132",
         "name": "Game 1",
         "img_icon_url": "746d1cd48fb2e57d579b05b6e9eccba95859e549"
     },
     {
-        "appid": "2",
+        "appid": "256",
         "name": "Game 2",
         "img_icon_url": "1711fd8c46d739feec76bd4a64eaeeca5b87e3a7"
     },
     {
-        "appid": "3",
+        "appid": "31234",
         "name": "Game 3",
         "img_icon_url": "7775d52b50f38367aeaeedad5d6d235da34a3c1f"
     },
     {
-        "appid": "4",
+        "appid": "954",
         "name": "Game 4",
         "img_icon_url": "fbe80c4743e226f0bf65559c91b12953d4446808"
     }


### PR DESCRIPTION
1) ownedGame model now has an auto incrementing id as primary key instead of using appid.  appid as primary key prevented 2 or more users from being able to have the same games.  PK's cannot be duplicated so it threw a duplication error when I made two users that had the same games.

2) Upon account creation, ownedGame table now fetches the new user's games using the provided steamid.